### PR TITLE
Fix not working with spaces in app.desktop `Name` field

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -194,4 +194,4 @@ else
 fi
 
 mkdir dist
-mv "$APP_SHORT_NAME"*.AppImage* dist/.
+mv "${APP_SHORT_NAME// /_}"*.AppImage* dist/.


### PR DESCRIPTION
appimagetool replaces spaces in the resulting appimage file name with underscores, this PR changes the script to handle that