### PR TITLE
Adding support for multiple desktop files for vscode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -155,12 +155,17 @@ chmod +x $APP_DIRECTORY/AppRun
 
 echo "==> Setup icons and desktop for $APP_SHORT_NAME AppImage"
 # Add defaults which we need for proper app image. Desktop files, icons.
-cp $APP_FILENAME $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
-sed -i '/VersionUrl/d' $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
-sed -i '/VersionFile/d' $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
-sed -i '/VersionBash/d' $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
-sed -i '/VersionIcon/d' $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
-sed -i '/VersionDirectory/d' $APP_DIRECTORY/"$APP_SHORT_NAME".desktop
+
+for DESKTOP_INPUT in app*.desktop; do
+    DESKTOP_OUTPUT="$APP_DIRECTORY/${DESKTOP_INPUT/app/$APP_SHORT_NAME}"
+    cp "$DESKTOP_INPUT" "$DESKTOP_OUTPUT"
+    sed -i '/VersionUrl/d' "$DESKTOP_OUTPUT"
+    sed -i '/VersionFile/d' "$DESKTOP_OUTPUT"
+    sed -i '/VersionBash/d' "$DESKTOP_OUTPUT"
+    sed -i '/VersionIcon/d' "$DESKTOP_OUTPUT"
+    sed -i '/VersionDirectory/d' "$DESKTOP_OUTPUT"
+    echo "Copied $DESKTOP_INPUT to $DESKTOP_OUTPUT"
+done
 
 ICON_PATH=$(find $APP_DEPLOY -type f -name "$APP_VERSION_ICON")
 ICON_EXTENSION="${ICON_PATH#*.}"

--- a/build.sh
+++ b/build.sh
@@ -189,13 +189,17 @@ echo "==> Build $APP_SHORT_NAME AppImage"
 wget https://github.com/AppImage/Appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
 chmod +x *.AppImage
 
+# Set the AppImage name explicitly to avoid issues with multiple desktop files
+export APPIMAGETOOL_APP_NAME="${APP_SHORT_NAME// /_}"
+export ARCH="x86_64"
+
 if [ "$GITHUB_RUNNING_ACTION" == true ]; then
-  ARCH=x86_64 ./appimagetool-x86_64.AppImage --comp zstd "$APP_DIRECTORY" -n -u "gh-releases-zsync|$GH_USER|$GH_REPO|latest|$APP_SHORT_NAME*.AppImage.zsync"
+  ./appimagetool-x86_64.AppImage --comp zstd "$APP_DIRECTORY" -n -u "gh-releases-zsync|$GH_USER|$GH_REPO|latest|$APP_SHORT_NAME*.AppImage.zsync"
   echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
   echo "APP_SHORT_NAME=$APP_SHORT_NAME" >> "$GITHUB_ENV"
   echo "APP_VERSION=$VERSION" >> "$GITHUB_ENV"
 else
-  ARCH=x86_64 ./appimagetool-x86_64.AppImage --comp zstd "$APP_DIRECTORY" -n
+  ./appimagetool-x86_64.AppImage --comp zstd "$APP_DIRECTORY" -n
 fi
 
 mkdir dist


### PR DESCRIPTION
Some applications, like VSCode & VSCode Insiders generate several .desktop files. For example, one to handle URL scheme.

This has been modified to copy all app*.desktop files into the build directory.

Here's a demonstration of this working. https://github.com/tyvsmith/VSCodeInsiders-AppImage